### PR TITLE
fix: add delimiter in class name match

### DIFF
--- a/content.js
+++ b/content.js
@@ -67,7 +67,7 @@
       var element = parentElement.children[i];
       for (var j = 0; j < element.classList.length; j++) {
         var className = element.classList[j];
-        if (className.indexOf(classNamePrefix) === 0) {
+        if (className.indexOf(classNamePrefix + '_') === 0) {
           return element;
         }
       }


### PR DESCRIPTION
findElementByClassNameStartsWithで"stage-header_stage-button_hkl9B"のようなクラスにマッチさせることを意図しているのに，"stage-header_stage-button-icon_3zzFK"にマッチしてしまうことを防ぐため，'_'を区切り文字として追加しました．